### PR TITLE
ADC_Init Fix

### DIFF
--- a/Arduino/ArduinoCore-Pico/PicoPinFunction.h
+++ b/Arduino/ArduinoCore-Pico/PicoPinFunction.h
@@ -137,7 +137,7 @@ class PicoPinFunction {
 
     protected:
         PinInfo* pinInfo;
-        bool adc_init_flag;
+        bool adc_init_flag = false;
         int current_adc;
 
         /// protected constructor because this is a singleton


### PR DESCRIPTION
The adc_init_flag should has a default value otherwise ADC will not be initialized, all funtion depended on it will stuck in run.